### PR TITLE
Improve CMake integration for third-party libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------------------
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(EACopy CXX)
 
 # NOTE: Only used in multi-configuration environments
@@ -11,9 +11,11 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "My multi config type
 # Options
 #-------------------------------------------------------------------------------------------
 option(EACOPY_BUILD_TESTS "Enable generation of build files for tests" OFF)
+option(EACOPY_BUILD_AS_LIBRARY "Build EACopy as a library for use in other projects" OFF)
+option(EACOPY_INSTALL "Install EACopy library and headers" OFF)
 
 if (WIN32)
-	SET(CMAKE_CXX_FLAGS "/GR-") 
+	SET(CMAKE_CXX_FLAGS "/GR-")
 endif(WIN32)
 
 if (UNIX)
@@ -22,41 +24,97 @@ endif (UNIX)
 
 
 #-------------------------------------------------------------------------------------------
+# External dependencies paths
+#-------------------------------------------------------------------------------------------
+set(EACOPY_EXTERNAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external")
+set(EACOPY_ZSTD_DIR "${EACOPY_EXTERNAL_DIR}/zstd")
+set(EACOPY_LZMA_DIR "${EACOPY_EXTERNAL_DIR}/lzma")
+set(EACOPY_XDELTA_DIR "${EACOPY_EXTERNAL_DIR}/xdelta")
+
+#-------------------------------------------------------------------------------------------
+# Options for external dependencies
+#-------------------------------------------------------------------------------------------
+option(EACOPY_USE_SYSTEM_ZSTD "Use system zstd library instead of bundled one" OFF)
+option(EACOPY_USE_SYSTEM_LZMA "Use system lzma library instead of bundled one" OFF)
+option(EACOPY_USE_SYSTEM_XDELTA "Use system xdelta library instead of bundled one" OFF)
+
+#-------------------------------------------------------------------------------------------
 # Zstd
 #-------------------------------------------------------------------------------------------
-set(ZSTD_BUILD_PROGRAMS OFF)
-set(ZSTD_BUILD_SHARED OFF)
-set(ZSTD_BUILD_TESTS OFF)
-set(ZSTD_STATIC_LINKING_ONLY ON)
-add_subdirectory(external/zstd/build/cmake)
-if (WIN32)
-	target_compile_options(libzstd_static PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
-endif(WIN32)
+if(EACOPY_USE_SYSTEM_ZSTD)
+    find_package(zstd REQUIRED)
+    set(ZSTD_LIBRARIES zstd::zstd)
+    add_library(libzstd_static ALIAS zstd::zstd)
+else()
+    set(ZSTD_BUILD_PROGRAMS OFF)
+    set(ZSTD_BUILD_SHARED OFF)
+    set(ZSTD_BUILD_TESTS OFF)
+    set(ZSTD_STATIC_LINKING_ONLY ON)
+    add_subdirectory(${EACOPY_ZSTD_DIR}/build/cmake)
+    if (WIN32)
+        target_compile_options(libzstd_static PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
+    endif(WIN32)
+endif()
 
 #-------------------------------------------------------------------------------------------
 # lzma
 #-------------------------------------------------------------------------------------------
-add_subdirectory(external/lzma)
-if (WIN32)
-	target_compile_options(lzma PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
-endif(WIN32)
+if(EACOPY_USE_SYSTEM_LZMA)
+    find_package(LibLZMA REQUIRED)
+    set(LZMA_LIBRARIES LibLZMA::LibLZMA)
+    add_library(lzma ALIAS LibLZMA::LibLZMA)
+else()
+    add_subdirectory(${EACOPY_LZMA_DIR})
+    if (WIN32)
+        target_compile_options(lzma PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
+    endif(WIN32)
+endif()
 
 #-------------------------------------------------------------------------------------------
 # xdelta
 #-------------------------------------------------------------------------------------------
-
-add_compile_definitions(SIZEOF_SIZE_T=8 SIZEOF_UNSIGNED_LONG_LONG=8 _WIN32=1 XD3_USE_LARGEFILE64=1 SECONDARY_DJW=1 SECONDARY_LZMA=1 SECONDARY_FGK=1 XD3_WIN32=1 LZMA_API_STATIC)
-add_subdirectory(external/xdelta)
-target_include_directories(xdelta PRIVATE external/lzma/liblzma/api)
-if (WIN32)
-	target_compile_options(xdelta PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
-endif(WIN32)
+if(EACOPY_USE_SYSTEM_XDELTA)
+    find_package(xdelta REQUIRED)
+    set(XDELTA_LIBRARIES xdelta::xdelta)
+    add_library(xdelta ALIAS xdelta::xdelta)
+else()
+    add_compile_definitions(SIZEOF_SIZE_T=8 SIZEOF_UNSIGNED_LONG_LONG=8 XD3_USE_LARGEFILE64=1 SECONDARY_DJW=1 SECONDARY_LZMA=1 SECONDARY_FGK=1 LZMA_API_STATIC)
+    if(WIN32)
+        add_compile_definitions(_WIN32=1 XD3_WIN32=1)
+    endif()
+    add_subdirectory(${EACOPY_XDELTA_DIR})
+    if(NOT EACOPY_USE_SYSTEM_LZMA)
+        target_include_directories(xdelta PRIVATE ${EACOPY_LZMA_DIR}/liblzma/api)
+    endif()
+    if (WIN32)
+        target_compile_options(xdelta PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")
+    endif(WIN32)
+endif()
 
 #-------------------------------------------------------------------------------------------
 # Library definitions
 #-------------------------------------------------------------------------------------------
 
-set(EACOPY_EXTERNAL_LIBS libzstd_static xdelta lzma)
+# Set external libraries list
+if(EACOPY_USE_SYSTEM_ZSTD)
+    set(EACOPY_ZSTD_LIB ${ZSTD_LIBRARIES})
+else()
+    set(EACOPY_ZSTD_LIB libzstd_static)
+endif()
+
+if(EACOPY_USE_SYSTEM_LZMA)
+    set(EACOPY_LZMA_LIB ${LZMA_LIBRARIES})
+else()
+    set(EACOPY_LZMA_LIB lzma)
+endif()
+
+if(EACOPY_USE_SYSTEM_XDELTA)
+    set(EACOPY_XDELTA_LIB ${XDELTA_LIBRARIES})
+else()
+    set(EACOPY_XDELTA_LIB xdelta)
+endif()
+
+set(EACOPY_EXTERNAL_LIBS ${EACOPY_ZSTD_LIB} ${EACOPY_XDELTA_LIB} ${EACOPY_LZMA_LIB})
 
 set(EACOPY_SHARED_FILES
 	${CMAKE_CURRENT_SOURCE_DIR}/include/EACopyNetwork.h
@@ -81,7 +139,23 @@ add_executable(EACopy
 	source/EACopyClient.cpp
 	${EACOPY_SHARED_FILES})
 
-target_include_directories(EACopy PUBLIC include)
+# Set include directories
+set(EACOPY_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+# Add third-party library include directories
+if(NOT EACOPY_USE_SYSTEM_ZSTD)
+    list(APPEND EACOPY_INCLUDE_DIRS ${EACOPY_ZSTD_DIR}/lib)
+endif()
+
+if(NOT EACOPY_USE_SYSTEM_LZMA)
+    list(APPEND EACOPY_INCLUDE_DIRS ${EACOPY_LZMA_DIR}/liblzma/api)
+endif()
+
+if(NOT EACOPY_USE_SYSTEM_XDELTA)
+    list(APPEND EACOPY_INCLUDE_DIRS ${EACOPY_XDELTA_DIR}/xdelta3)
+endif()
+
+target_include_directories(EACopy PUBLIC ${EACOPY_INCLUDE_DIRS})
 
 if (WIN32)
 	target_link_libraries(EACopy ${EACOPY_EXTERNAL_LIBS})
@@ -98,7 +172,7 @@ if (WIN32)
 		source/EACopyServer.cpp
 		${EACOPY_SHARED_FILES})
 
-	target_include_directories(EACopyService PUBLIC include)
+	target_include_directories(EACopyService PUBLIC ${EACOPY_INCLUDE_DIRS})
 	target_link_libraries(EACopyService ${EACOPY_EXTERNAL_LIBS})
 endif(WIN32)
 
@@ -106,4 +180,79 @@ endif(WIN32)
 if(EACOPY_BUILD_TESTS)
 	include(CTest)
 	add_subdirectory(test)
+endif()
+
+#-------------------------------------------------------------------------------------------
+# Library target for integration with other projects
+#-------------------------------------------------------------------------------------------
+if(EACOPY_BUILD_AS_LIBRARY)
+	# Create a static library target
+	add_library(EACopyLib STATIC
+		${EACOPY_SHARED_FILES}
+		include/EACopyClient.h
+		source/EACopyClient.cpp
+	)
+
+	# Set include directories
+	target_include_directories(EACopyLib PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+		$<INSTALL_INTERFACE:include>
+	)
+
+	# Link with dependencies
+	if (WIN32)
+		target_link_libraries(EACopyLib ${EACOPY_EXTERNAL_LIBS})
+	endif(WIN32)
+
+	if (UNIX)
+		target_link_libraries(EACopyLib ${EACOPY_EXTERNAL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+	endif (UNIX)
+
+	# Add compile definitions
+	target_compile_definitions(EACopyLib PUBLIC EACOPY_ALLOW_DELTA_COPY)
+endif()
+
+#-------------------------------------------------------------------------------------------
+# Installation rules
+#-------------------------------------------------------------------------------------------
+if(EACOPY_INSTALL)
+	include(GNUInstallDirs)
+
+	# Install headers
+	install(DIRECTORY include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/eacopy
+		FILES_MATCHING PATTERN "*.h"
+	)
+
+	if(EACOPY_BUILD_AS_LIBRARY)
+		# Install library
+		install(TARGETS EACopyLib
+			EXPORT EACopyTargets
+			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+			INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+		)
+
+		# Install CMake configuration files
+		install(EXPORT EACopyTargets
+			FILE EACopyTargets.cmake
+			NAMESPACE EACopy::
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/EACopy
+		)
+
+		# Create and install config file
+		include(CMakePackageConfigHelpers)
+		configure_package_config_file(
+			${CMAKE_CURRENT_SOURCE_DIR}/cmake/EACopyConfig.cmake.in
+			${CMAKE_CURRENT_BINARY_DIR}/EACopyConfig.cmake
+			INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/EACopy
+		)
+
+		# Install config file
+		install(FILES
+			${CMAKE_CURRENT_BINARY_DIR}/EACopyConfig.cmake
+			DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/EACopy
+		)
+	endif()
 endif()

--- a/cmake/EACopyConfig.cmake.in
+++ b/cmake/EACopyConfig.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+# Include targets file
+include("${CMAKE_CURRENT_LIST_DIR}/EACopyTargets.cmake")
+
+# Define exported targets
+set(EACOPY_LIBRARIES EACopy::EACopyLib)
+set(EACOPY_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/eacopy")
+
+# Check dependencies
+include(CMakeFindDependencyMacro)
+
+# Set package found flag
+set(EACOPY_FOUND TRUE)

--- a/include/EACopyDependencies.h
+++ b/include/EACopyDependencies.h
@@ -1,0 +1,26 @@
+// (c) Electronic Arts. All Rights Reserved.
+#pragma once
+
+// Central management of all third-party dependencies
+// This allows other files to include this header instead of directly referencing third-party library paths
+
+// ZSTD
+#ifdef EACOPY_USE_SYSTEM_ZSTD
+    #include <zstd.h>
+#else
+    #include "../external/zstd/lib/zstd.h"
+#endif
+
+// LZMA
+#ifdef EACOPY_USE_SYSTEM_LZMA
+    #include <lzma.h>
+#else
+    #include "../external/lzma/liblzma/api/lzma.h"
+#endif
+
+// XDELTA
+#ifdef EACOPY_USE_SYSTEM_XDELTA
+    #include <xdelta3.h>
+#else
+    #include "../external/xdelta/xdelta3/xdelta3.h"
+#endif

--- a/source/EACopyDeltaXDelta.h
+++ b/source/EACopyDeltaXDelta.h
@@ -3,7 +3,7 @@
 #if defined(EACOPY_ALLOW_DELTA_COPY)
 
 #include <EACopyDelta.h>
-#include <xdelta3.h>
+#include "EACopyDependencies.h"
 
 namespace eacopy
 {

--- a/source/EACopyDeltaZstd.h
+++ b/source/EACopyDeltaZstd.h
@@ -4,7 +4,7 @@
 
 #include <EACopyDelta.h>
 #define ZSTD_STATIC_LINKING_ONLY
-#include "../external/zstd/lib/zstd.h"
+#include "EACopyDependencies.h"
 #include <winsock2.h>
 
 namespace eacopy

--- a/source/EACopyNetwork.cpp
+++ b/source/EACopyNetwork.cpp
@@ -24,7 +24,7 @@
 #endif
 
 #define ZSTD_STATIC_LINKING_ONLY
-#include "../external/zstd/lib/zstd.h"
+#include "EACopyDependencies.h"
 
 #if defined(_WIN32)
 #else
@@ -79,11 +79,11 @@ bool isLocalHost(const wchar_t* hostname, WString& outIp)
 
 	freeAddrInfo(hostaddr);
 	freeAddrInfo(localaddr);
-	
+
 	#if defined(_WIN32)
 	WSACleanup();
 	#endif
-	
+
 	return isLocal;
 }
 


### PR DESCRIPTION
# Improve CMake Integration for Third-Party Libraries

This PR improves the CMake integration for EACopy, making it easier to use as a library in other projects.

## Changes

1. Created a central dependency management header (`EACopyDependencies.h`) to handle third-party library includes
2. Modified CMakeLists.txt to use relative path variables for third-party libraries
3. Added options to use system libraries instead of bundled ones
4. Created CMake configuration files for better integration with other projects

## Benefits

- Easier integration with other projects through `find_package(EACopy)`
- Better control over third-party library versions
- Reduced path dependency issues
- More flexible build configuration