### PR TITLE
Improve performance test reporting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,17 +163,97 @@ jobs:
             Write-Host "Performance test timed out after $timeout seconds" -ForegroundColor Red
             Stop-Job $job
 
-            # Create a minimal performance report
-            $MinimalReport = "## EACopy vs Robocopy Performance Test Results`n`nTest timed out after $timeout seconds. This may indicate performance issues or environment constraints in CI.`n`n### Test Configuration (Minimal)`n- Small Files: 20 files of 1KB each`n- Medium Files: 5 files of 100KB each`n- Large Files: 2 files of 1MB each"
+            # Create a more detailed performance report even when timeout occurs
+            # Run a simplified version of the test with even smaller file counts
+            Write-Host "Running simplified performance test after timeout..."
+
+            # Create minimal test files directly
+            $SourceDir = "./perf_test/source"
+            $DestDir1 = "./perf_test/dest_eacopy"
+            $DestDir2 = "./perf_test/dest_robocopy"
+
+            New-Item -ItemType Directory -Force -Path $SourceDir | Out-Null
+            New-Item -ItemType Directory -Force -Path $DestDir1 | Out-Null
+            New-Item -ItemType Directory -Force -Path $DestDir2 | Out-Null
+
+            # Create just a few small test files
+            $SmallFileCount = 5
+            $SmallFileSize = 1KB
+
+            Write-Host "Creating $SmallFileCount small test files..."
+            for ($i = 1; $i -le $SmallFileCount; $i++) {
+                $FilePath = Join-Path $SourceDir "small_file_$i.dat"
+                $Buffer = New-Object byte[] $SmallFileSize
+                (New-Object Random).NextBytes($Buffer)
+                [System.IO.File]::WriteAllBytes($FilePath, $Buffer)
+            }
+
+            # Measure EACopy performance
+            Write-Host "Testing EACopy performance..."
+            $EACopyStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+            & $EACopyPath $SourceDir $DestDir1 | Out-Null
+            $EACopyStopWatch.Stop()
+            $EACopyTime = $EACopyStopWatch.Elapsed.TotalSeconds
+
+            # Measure Robocopy performance
+            Write-Host "Testing Robocopy performance..."
+            $RobocopyStopWatch = [System.Diagnostics.Stopwatch]::StartNew()
+            & robocopy $SourceDir $DestDir2 /E | Out-Null
+            $RobocopyStopWatch.Stop()
+            $RobocopyTime = $RobocopyStopWatch.Elapsed.TotalSeconds
+
+            # Calculate difference
+            $TimeDiff = $RobocopyTime - $EACopyTime
+            $TimeDiffPercent = if ($RobocopyTime -gt 0) {
+                [Math]::Round(($TimeDiff / $RobocopyTime) * 100, 2)
+            } else {
+                0
+            }
+
+            $FasterTool = if ($EACopyTime -lt $RobocopyTime) { "EACopy" } else { "Robocopy" }
+
+            # Create the report content
+            $ReportTitle = "## EACopy vs Robocopy Performance Test Results"
+            $TimeoutInfo = "The full test timed out after $timeout seconds, but a simplified test was completed."
+            $ResultsHeader = "### Simplified Test Results"
+
+            $EACopyTimeRounded = [Math]::Round($EACopyTime, 2)
+            $RobocopyTimeRounded = [Math]::Round($RobocopyTime, 2)
+            $TimeDiffRounded = [Math]::Round($TimeDiff, 2)
+
+            $MinimalReport = "$ReportTitle`n`n$TimeoutInfo`n`n$ResultsHeader`n"
+            $MinimalReport += "| Tool | Time (seconds) |`n"
+            $MinimalReport += "|------|---------------|`n"
+            $MinimalReport += "| EACopy | $EACopyTimeRounded |`n"
+            $MinimalReport += "| Robocopy | $RobocopyTimeRounded |`n"
+            $MinimalReport += "| Difference | $TimeDiffRounded ($TimeDiffPercent%) |`n"
+            $MinimalReport += "| Faster Tool | $FasterTool |`n`n"
+            $MinimalReport += "### Test Configuration (Minimal)`n"
+            $MinimalReport += "- Small Files: $SmallFileCount files of $SmallFileSize each"
 
             # Ensure directory exists before writing file
             New-Item -ItemType Directory -Force -Path "./perf_test" | Out-Null
             $MinimalReport | Out-File -FilePath "./perf_test/performance_results.md" -Encoding utf8
 
-            # Create empty JSON file for compatibility with other steps
+            # Create JSON file with the simplified test results
             @{
                 TestDate = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
-                TestResults = @()
+                TestResults = @(
+                    @{
+                        ScenarioName = "Simplified Test"
+                        EACopy = @{
+                            ElapsedSeconds = [Math]::Round($EACopyTime, 2)
+                            ThroughputMBps = 0
+                        }
+                        Robocopy = @{
+                            ElapsedSeconds = [Math]::Round($RobocopyTime, 2)
+                            ThroughputMBps = 0
+                        }
+                        TimeDiff = [Math]::Round($TimeDiff, 2)
+                        TimeDiffPercent = $TimeDiffPercent
+                        FasterTool = $FasterTool
+                    }
+                )
             } | ConvertTo-Json -Depth 5 | Out-File -FilePath "./perf_test/performance_results.json" -Encoding utf8
         }
         Remove-Job $job -Force

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ if(NOT EACOPY_USE_SYSTEM_XDELTA)
 endif()
 
 target_include_directories(EACopy PUBLIC ${EACOPY_INCLUDE_DIRS})
+target_compile_definitions(EACopy PRIVATE _HAS_EXCEPTIONS=0)
 
 if (WIN32)
 	target_link_libraries(EACopy ${EACOPY_EXTERNAL_LIBS})
@@ -173,6 +174,7 @@ if (WIN32)
 		${EACOPY_SHARED_FILES})
 
 	target_include_directories(EACopyService PUBLIC ${EACOPY_INCLUDE_DIRS})
+	target_compile_definitions(EACopyService PRIVATE _HAS_EXCEPTIONS=0)
 	target_link_libraries(EACopyService ${EACOPY_EXTERNAL_LIBS})
 endif(WIN32)
 
@@ -209,6 +211,7 @@ if(EACOPY_BUILD_AS_LIBRARY)
 	endif (UNIX)
 
 	# Add compile definitions
+	target_compile_definitions(EACopyLib PRIVATE _HAS_EXCEPTIONS=0)
 	target_compile_definitions(EACopyLib PUBLIC EACOPY_ALLOW_DELTA_COPY)
 endif()
 

--- a/include/EACopyShared.h
+++ b/include/EACopyShared.h
@@ -3,7 +3,9 @@
 #pragma once
 #undef UNICODE
 #define WIN32_LEAN_AND_MEAN
+#ifndef _HAS_EXCEPTIONS
 #define _HAS_EXCEPTIONS 0
+#endif
 
 #include <functional>
 #include <list>
@@ -82,7 +84,7 @@ private:
 	u64					data[5];
 };
 
-class ScopedCriticalSection 
+class ScopedCriticalSection
 {
 public:
 	ScopedCriticalSection(CriticalSection& cs) : m_cs(cs), m_active(true) { cs.enter(); }
@@ -473,11 +475,11 @@ uint GetLastError();
 #define MAX_PATH 260
 #define _wcsicmp wcscasecmp
 #define _wcsnicmp wcsncasecmp
-#define FILE_ATTRIBUTE_READONLY             0x00000001  
-#define FILE_ATTRIBUTE_HIDDEN               0x00000002  
-#define FILE_ATTRIBUTE_DIRECTORY            0x00000010  
-#define FILE_ATTRIBUTE_NORMAL               0x00000080  
-#define FILE_ATTRIBUTE_REPARSE_POINT        0x00000400  
+#define FILE_ATTRIBUTE_READONLY             0x00000001
+#define FILE_ATTRIBUTE_HIDDEN               0x00000002
+#define FILE_ATTRIBUTE_DIRECTORY            0x00000010
+#define FILE_ATTRIBUTE_NORMAL               0x00000080
+#define FILE_ATTRIBUTE_REPARSE_POINT        0x00000400
 #define ERROR_FILE_NOT_FOUND             2L
 #define ERROR_PATH_NOT_FOUND             3L
 #define ERROR_INVALID_HANDLE             6L


### PR DESCRIPTION
## Problem
Currently, when performance tests time out in CI, we only get a generic message without any actual timing data:

```
Test timed out after 300 seconds. This may indicate performance issues or environment constraints in CI.

Test Configuration (Minimal)
- Small Files: 20 files of 1KB each
- Medium Files: 5 files of 100KB each
- Large Files: 2 files of 1MB each
```

## Solution
This PR improves the performance test reporting by:

1. Adding a simplified performance test that runs when the main test times out
2. Showing actual timing data even when the full test cannot complete
3. Providing a more detailed comparison between EACopy and Robocopy

## Benefits
- Better visibility into performance even when tests time out
- More useful data for comparing EACopy and Robocopy
- Helps identify if timeouts are due to performance issues or CI environment constraints