### PR TITLE
Fix x64 build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         mkdir build_${{ matrix.config }}
         cd build_${{ matrix.config }}
         # Add MSG_WAITALL definition for Windows platform
-        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8"
+        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
         mkdir build_${{ matrix.config }}
         cd build_${{ matrix.config }}
         # Add MSG_WAITALL definition for Windows platform
-        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+        # Disable zstd programs, shared libs and tests to avoid CMake version compatibility issues
+        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8" -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_TESTS=OFF
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,17 @@ jobs:
     - name: Setup ccache
       uses: hendrikmuhs/ccache-action@v1.2.11
 
+    - name: Setup CMake
+      uses: jwlawson/actions-setup-cmake@v1.13
+      with:
+        cmake-version: '3.26.x'
+
     - name: Configure CMake
       run: |
         mkdir build_${{ matrix.config }}
         cd build_${{ matrix.config }}
         # Add MSG_WAITALL definition for Windows platform
-        # Disable zstd programs, shared libs and tests to avoid CMake version compatibility issues
-        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8" -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_TESTS=OFF
+        cmake .. -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS="/DMSG_WAITALL=0x8"
 
     - name: Build
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 #-------------------------------------------------------------------------------------------
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
+# Note: This CMakeLists.txt has been modified to support integration with py-eacopy
+# and other projects that use EACopy as a library.
+#-------------------------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.5)
 project(EACopy CXX)
 
@@ -11,11 +14,31 @@ set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "My multi config type
 # Options
 #-------------------------------------------------------------------------------------------
 option(EACOPY_BUILD_TESTS "Enable generation of build files for tests" OFF)
-option(EACOPY_BUILD_AS_LIBRARY "Build EACopy as a library for use in other projects" OFF)
-option(EACOPY_INSTALL "Install EACopy library and headers" OFF)
+option(EACOPY_BUILD_AS_LIBRARY "Build EACopy as a library for use in other projects" ON)
+option(EACOPY_INSTALL "Install EACopy library and headers" ON)
 
 if (WIN32)
 	SET(CMAKE_CXX_FLAGS "/GR-")
+
+	# Add Windows-specific compile options
+	add_compile_options(
+		/W3     # Warning level 3
+		/MP     # Multi-processor compilation
+		/wd4244 # Disable warning C4244: conversion from 'double' to 'float'
+		/wd4267 # Disable warning C4267: conversion from 'size_t' to 'int'
+		/wd4305 # Disable warning C4305: truncation from 'double' to 'float'
+		/bigobj # Support for large object files
+	)
+
+	# Use dynamic runtime library (MD/MDd) instead of static (MT/MTd)
+	# This is critical for compatibility with Python extensions
+	foreach(flag_var
+		CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+		CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE)
+		if(${flag_var} MATCHES "/MT")
+			string(REGEX REPLACE "/MT" "/MD" ${flag_var} "${${flag_var}}")
+		endif()
+	endforeach()
 endif(WIN32)
 
 if (UNIX)
@@ -209,7 +232,19 @@ if(EACOPY_BUILD_AS_LIBRARY)
 	endif (UNIX)
 
 	# Add compile definitions
-	target_compile_definitions(EACopyLib PUBLIC EACOPY_ALLOW_DELTA_COPY)
+	target_compile_definitions(EACopyLib PUBLIC
+			EACOPY_ALLOW_DELTA_COPY
+			$<$<BOOL:${WIN32}>:NOMINMAX>
+			$<$<BOOL:${WIN32}>:WIN32_LEAN_AND_MEAN>
+		)
+
+		# Add Windows-specific compile options for EACopyLib
+		if(MSVC)
+			target_compile_options(EACopyLib PRIVATE
+				$<$<CONFIG:Debug>:/MDd>
+				$<$<CONFIG:Release>:/MD>
+			)
+		endif()
 endif()
 
 #-------------------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,31 @@
 # Note: This CMakeLists.txt has been modified to support integration with py-eacopy
 # and other projects that use EACopy as a library.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
+
+# Set CMake policy version for compatibility with older CMake files in submodules
+if(POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)  # project() command manages VERSION variables
+endif()
+if(POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)  # option() honors normal variables
+endif()
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)  # MSVC runtime library flags
+endif()
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)  # find_package uses <PackageName>_ROOT variables
+endif()
+
+# Set CMAKE_POLICY_DEFAULT to handle policies in subdirectories
+set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+
+# Define ZSTD_MAX_VALIDATED_CMAKE_MAJOR_VERSION and ZSTD_MAX_VALIDATED_CMAKE_MINOR_VERSION
+# to avoid issues with zstd's CMakeLists.txt
+set(ZSTD_MAX_VALIDATED_CMAKE_MAJOR_VERSION "3" CACHE STRING "ZSTD max validated CMake major version" FORCE)
+set(ZSTD_MAX_VALIDATED_CMAKE_MINOR_VERSION "26" CACHE STRING "ZSTD max validated CMake minor version" FORCE)
+
 project(EACopy CXX)
 
 # NOTE: Only used in multi-configuration environments
@@ -69,10 +93,13 @@ if(EACOPY_USE_SYSTEM_ZSTD)
     set(ZSTD_LIBRARIES zstd::zstd)
     add_library(libzstd_static ALIAS zstd::zstd)
 else()
-    set(ZSTD_BUILD_PROGRAMS OFF)
-    set(ZSTD_BUILD_SHARED OFF)
-    set(ZSTD_BUILD_TESTS OFF)
-    set(ZSTD_STATIC_LINKING_ONLY ON)
+    # Set zstd build options
+    set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "Build zstd programs" FORCE)
+    set(ZSTD_BUILD_SHARED OFF CACHE BOOL "Build zstd shared library" FORCE)
+    set(ZSTD_BUILD_TESTS OFF CACHE BOOL "Build zstd tests" FORCE)
+    set(ZSTD_STATIC_LINKING_ONLY ON CACHE BOOL "Build zstd static library only" FORCE)
+
+    # Simply use the original zstd CMakeLists.txt with our CMake policy settings
     add_subdirectory(${EACOPY_ZSTD_DIR}/build/cmake)
     if (WIN32)
         target_compile_options(libzstd_static PUBLIC "$<$<CONFIG:RELEASE>:/Oi>")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Note: This CMakeLists.txt has been modified to support integration with py-eacopy
 # and other projects that use EACopy as a library.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(EACopy CXX)
 
 # NOTE: Only used in multi-configuration environments
@@ -260,7 +260,38 @@ if(EACOPY_INSTALL)
 	)
 
 	if(EACOPY_BUILD_AS_LIBRARY)
-		# Install library
+		# Install library and dependencies
+		if(NOT EACOPY_USE_SYSTEM_ZSTD)
+			install(TARGETS libzstd_static
+				EXPORT EACopyTargets
+				LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+				INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+			)
+		endif()
+
+		if(NOT EACOPY_USE_SYSTEM_LZMA)
+			install(TARGETS lzma
+				EXPORT EACopyTargets
+				LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+				INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+			)
+		endif()
+
+		if(NOT EACOPY_USE_SYSTEM_XDELTA)
+			install(TARGETS xdelta
+				EXPORT EACopyTargets
+				LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+				RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+				INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+			)
+		endif()
+
+		# Install main library
 		install(TARGETS EACopyLib
 			EXPORT EACopyTargets
 			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/cmake/EACopyConfig.cmake.in
+++ b/cmake/EACopyConfig.cmake.in
@@ -10,5 +10,18 @@ set(EACOPY_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/eacopy")
 # Check dependencies
 include(CMakeFindDependencyMacro)
 
+# Find system dependencies if needed
+if(@EACOPY_USE_SYSTEM_ZSTD@)
+    find_dependency(zstd)
+endif()
+
+if(@EACOPY_USE_SYSTEM_LZMA@)
+    find_dependency(LibLZMA)
+endif()
+
+if(@EACOPY_USE_SYSTEM_XDELTA@)
+    find_dependency(xdelta)
+endif()
+
 # Set package found flag
 set(EACOPY_FOUND TRUE)

--- a/include/EACopyNetwork.h
+++ b/include/EACopyNetwork.h
@@ -4,8 +4,18 @@
 #include "EACopyShared.h"
 #include <cstring>
 
+#if defined(_WIN32)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#else
 typedef eacopy::u64 SOCKET;
+#define EACOPY_DEFINED_SOCKET
+#endif
+
+#if !defined(_WIN32) && !defined(INVALID_SOCKET)
 #define INVALID_SOCKET  (SOCKET)(~0)
+#endif
 
 struct Guid {
     unsigned long  Data1;

--- a/include/EACopyShared.h
+++ b/include/EACopyShared.h
@@ -3,7 +3,10 @@
 #pragma once
 #undef UNICODE
 #define WIN32_LEAN_AND_MEAN
+// Only define _HAS_EXCEPTIONS if it's not already defined
+#ifndef _HAS_EXCEPTIONS
 #define _HAS_EXCEPTIONS 0
+#endif
 
 #include <functional>
 #include <list>

--- a/include/EACopyShared.h
+++ b/include/EACopyShared.h
@@ -2,7 +2,9 @@
 
 #pragma once
 #undef UNICODE
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 // Only define _HAS_EXCEPTIONS if it's not already defined
 #ifndef _HAS_EXCEPTIONS
 #define _HAS_EXCEPTIONS 0
@@ -85,7 +87,7 @@ private:
 	u64					data[5];
 };
 
-class ScopedCriticalSection 
+class ScopedCriticalSection
 {
 public:
 	ScopedCriticalSection(CriticalSection& cs) : m_cs(cs), m_active(true) { cs.enter(); }
@@ -476,11 +478,11 @@ uint GetLastError();
 #define MAX_PATH 260
 #define _wcsicmp wcscasecmp
 #define _wcsnicmp wcsncasecmp
-#define FILE_ATTRIBUTE_READONLY             0x00000001  
-#define FILE_ATTRIBUTE_HIDDEN               0x00000002  
-#define FILE_ATTRIBUTE_DIRECTORY            0x00000010  
-#define FILE_ATTRIBUTE_NORMAL               0x00000080  
-#define FILE_ATTRIBUTE_REPARSE_POINT        0x00000400  
+#define FILE_ATTRIBUTE_READONLY             0x00000001
+#define FILE_ATTRIBUTE_HIDDEN               0x00000002
+#define FILE_ATTRIBUTE_DIRECTORY            0x00000010
+#define FILE_ATTRIBUTE_NORMAL               0x00000080
+#define FILE_ATTRIBUTE_REPARSE_POINT        0x00000400
 #define ERROR_FILE_NOT_FOUND             2L
 #define ERROR_PATH_NOT_FOUND             3L
 #define ERROR_INVALID_HANDLE             6L

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -3,7 +3,7 @@
 
 rem @call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
 rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
-@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON
+@call cmake .. -G "Visual Studio 17 2022" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
 @call cmake --build . --config Release
 @call cmake --build . --config Debug
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -3,7 +3,7 @@
 
 rem @call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
 rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
-@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_TESTS=OFF
 @call cmake --build . --config Release
 @call cmake --build . --config Debug
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -3,7 +3,7 @@
 
 rem @call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
 rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
-@call cmake .. -G "Visual Studio 17 2022" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
+@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON
 @call cmake --build . --config Release
 @call cmake --build . --config Debug
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -3,7 +3,7 @@
 
 rem @call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
 rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
-@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_SHARED=OFF -DZSTD_BUILD_TESTS=OFF
+@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 @call cmake --build . --config Release
 @call cmake --build . --config Debug
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -3,7 +3,7 @@
 
 rem @call cmake .. -G "Visual Studio 15 2017 Win64" -DEACOPY_BUILD_TESTS:BOOL=ON
 rem @call cmake .. -G "Visual Studio 16 2019" -A x64 -DEACOPY_BUILD_TESTS:BOOL=ON
-@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON
+@call cmake .. -G "Visual Studio 17 2022" -DEACOPY_BUILD_TESTS:BOOL=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 @call cmake --build . --config Release
 @call cmake --build . --config Debug
 

--- a/source/EACopyDeltaXDelta.h
+++ b/source/EACopyDeltaXDelta.h
@@ -235,7 +235,7 @@ bool xDeltaCode(bool encode, Socket& socket, const wchar_t* referenceFileName, F
 
 	xd3_config config;
 	xd3_init_config(&config, flags);
-	config.winsize = min(referenceFileSize, XD3_DEFAULT_WINSIZE);
+	config.winsize = eacopy::min<eacopy::u64>(referenceFileSize, static_cast<eacopy::u64>(XD3_DEFAULT_WINSIZE));
 	config.getblk = xDeltaGetBlock;
 	config.opaque = &blockData;
 	config.iopt_size = XD3_DEFAULT_IOPT_SIZE;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------------------
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(EACopyTest CXX)
 
 include(CTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 #-------------------------------------------------------------------------------------------
 # Copyright (C) Electronic Arts Inc.  All rights reserved.
 #-------------------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 project(EACopyTest CXX)
 
 include(CTest)


### PR DESCRIPTION
This PR addresses x64 architecture build issues and enhances CMake configuration for better integration with py-eacopy:

1. Explicitly specifying x64 architecture in build.bat
   - Added `-A x64` parameter to the CMake command to ensure proper x64 architecture selection

2. Fixing SOCKET type redefinition in EACopyNetwork.h
   - Removed duplicate `typedef eacopy::u64 SOCKET;` declaration
   - Added conditional compilation for INVALID_SOCKET definition

3. Enhanced CMake configuration for py-eacopy integration
   - Enabled EACOPY_BUILD_AS_LIBRARY and EACOPY_INSTALL options by default
   - Added Windows-specific compile options (/W3, /MP, /bigobj)
   - Disabled specific warnings (C4244, C4267, C4305)
   - Configured dynamic runtime library (MD/MDd) for Python compatibility
   - Added NOMINMAX and WIN32_LEAN_AND_MEAN definitions

These changes ensure that the project builds correctly on x64 architecture and can be easily integrated with py-eacopy and other projects.

Signed-off-by: Hal <hal.long@outlook.com>