### PR TITLE
Fix CI release issues - version detection and missing executables

### DIFF
--- a/.github/scripts/update-vcpkg-registry.sh
+++ b/.github/scripts/update-vcpkg-registry.sh
@@ -76,39 +76,19 @@ if [[ ! -f "$BASELINE_JSON_PATH" ]]; then
   exit 1
 fi
 
-# Calculate git-tree after all file updates
-if [[ "$DRY_RUN" == "false" ]]; then
-  echo "Calculating git-tree after file updates..."
-
-  # Stage the changes to get the correct git-tree
-  git add vcpkg-registry/
-
-  # Calculate git-tree for the ports/eacopy directory
-  GIT_TREE=$(git write-tree --prefix=vcpkg-registry/ports/eacopy/)
-  echo "Git-tree hash: $GIT_TREE"
-else
-  # For dry run, use current HEAD as placeholder
-  GIT_TREE=$(git rev-parse HEAD)
-  echo "Current git-tree (dry run): $GIT_TREE"
-fi
-
-# Update portfile.cmake
+# Update portfile.cmake first
 if [[ "$DRY_RUN" == "false" ]]; then
   echo "Updating $PORTFILE_PATH..."
 
-  # Update the REF line to point to the current commit
-  sed -i "s|REF [a-f0-9]*|REF $GIT_TREE|g" "$PORTFILE_PATH"
-
-  # If using pre-built binaries approach (like xdelta), update SHA512
+  # Update SHA512 hash for pre-built binaries
   if grep -q "SHA512" "$PORTFILE_PATH"; then
     sed -i 's|SHA512 "to-be-filled-after-release"|SHA512 "'"$SHA512"'"|g' "$PORTFILE_PATH"
     sed -i 's|SHA512 "[a-f0-9]*"|SHA512 "'"$SHA512"'"|g' "$PORTFILE_PATH"
     echo "✅ Updated SHA512 in portfile.cmake"
   fi
 
-  echo "✅ Updated REF in portfile.cmake"
+  echo "✅ Updated portfile.cmake"
 else
-  echo "[DRY RUN] Would update REF in $PORTFILE_PATH to: $GIT_TREE"
   if grep -q "SHA512" "$PORTFILE_PATH"; then
     echo "[DRY RUN] Would update SHA512 in $PORTFILE_PATH to: $SHA512"
   fi
@@ -123,15 +103,13 @@ else
   echo "[DRY RUN] Would update version in $VCPKG_JSON_PATH to: $VERSION"
 fi
 
-# Update versions/e-/eacopy.json
+# Update versions/e-/eacopy.json (version only, git-tree will be updated later)
 if [[ "$DRY_RUN" == "false" ]]; then
   echo "Updating $VERSION_JSON_PATH..."
   sed -i 's|"version": "[0-9.]*"|"version": "'"$VERSION"'"|g' "$VERSION_JSON_PATH"
-  sed -i 's|"git-tree": "[a-f0-9]*"|"git-tree": "'"$GIT_TREE"'"|g' "$VERSION_JSON_PATH"
-  echo "✅ Updated version and git-tree in eacopy.json"
+  echo "✅ Updated version in eacopy.json"
 else
   echo "[DRY RUN] Would update version in $VERSION_JSON_PATH to: $VERSION"
-  echo "[DRY RUN] Would update git-tree in $VERSION_JSON_PATH to: $GIT_TREE"
 fi
 
 # Update baseline.json
@@ -141,6 +119,30 @@ if [[ "$DRY_RUN" == "false" ]]; then
   echo "✅ Updated baseline in baseline.json"
 else
   echo "[DRY RUN] Would update baseline in $BASELINE_JSON_PATH to: $VERSION"
+fi
+
+# Calculate git-tree after all file updates
+if [[ "$DRY_RUN" == "false" ]]; then
+  echo "Calculating git-tree after file updates..."
+
+  # Stage the changes to get the correct git-tree
+  git add vcpkg-registry/
+
+  # Calculate git-tree for the ports/eacopy directory
+  GIT_TREE=$(git write-tree --prefix=vcpkg-registry/ports/eacopy/)
+  echo "Git-tree hash: $GIT_TREE"
+
+  # Update git-tree in versions/e-/eacopy.json
+  echo "Updating git-tree in $VERSION_JSON_PATH..."
+  sed -i 's|"git-tree": "to-be-filled-after-release"|"git-tree": "'"$GIT_TREE"'"|g' "$VERSION_JSON_PATH"
+  sed -i 's|"git-tree": "placeholder"|"git-tree": "'"$GIT_TREE"'"|g' "$VERSION_JSON_PATH"
+  sed -i 's|"git-tree": "[a-f0-9]\{40\}"|"git-tree": "'"$GIT_TREE"'"|g' "$VERSION_JSON_PATH"
+  sed -i 's|"git-tree": "[a-f0-9]*"|"git-tree": "'"$GIT_TREE"'"|g' "$VERSION_JSON_PATH"
+  echo "✅ Updated git-tree in eacopy.json"
+else
+  # For dry run, use current HEAD as placeholder
+  GIT_TREE=$(git rev-parse HEAD)
+  echo "[DRY RUN] Would update git-tree in $VERSION_JSON_PATH to: $GIT_TREE"
 fi
 
 echo "Registry update complete!"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,35 +35,51 @@ jobs:
           # For release event, extract version from tag
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
+          echo "Extracted version from release tag: $VERSION"
         elif [[ "${{ github.event.inputs.version }}" != "" ]]; then
           # For workflow_dispatch with version input
           VERSION="${{ github.event.inputs.version }}"
+          echo "Using version from workflow input: $VERSION"
         else
           # Extract from CMakeLists.txt - look for project version
-          VERSION=$(grep -o 'project(EACopy.*VERSION [0-9.]*' CMakeLists.txt | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+')
+          echo "Extracting version from CMakeLists.txt..."
 
-          # If that fails, try a simpler pattern
+          # More robust version extraction that handles the specific format in CMakeLists.txt
+          VERSION=$(grep -E '^project\(EACopy\s+VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+          # If that fails, try alternative patterns
           if [[ -z "$VERSION" ]]; then
-            echo "First extraction method failed, trying alternative..."
-            VERSION=$(grep 'VERSION' CMakeLists.txt | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
+            echo "First extraction method failed, trying alternative patterns..."
+            # Try to find any line with VERSION followed by a version number
+            VERSION=$(grep -E 'VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          fi
+
+          # If still no version, try even simpler pattern
+          if [[ -z "$VERSION" ]]; then
+            echo "Second extraction method failed, trying simpler pattern..."
+            VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt | head -1)
           fi
 
           # If still no version, use hardcoded fallback
           if [[ -z "$VERSION" ]]; then
-            echo "Could not extract version from CMakeLists.txt"
-            VERSION="1.0.0"
+            echo "❌ Could not extract version from CMakeLists.txt"
+            echo "CMakeLists.txt content around project line:"
+            grep -n -A2 -B2 "project" CMakeLists.txt || echo "No project line found"
+            VERSION="1.20.0"
             echo "Using fallback version: $VERSION"
+          else
+            echo "✅ Successfully extracted version from CMakeLists.txt: $VERSION"
           fi
         fi
 
-        # Validate version format
+        # Validate version format - allow X.Y.Z format
         if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "Warning: Version format is not X.Y.Z: '$VERSION'"
-          echo "Falling back to hardcoded version 1.0.0"
-          VERSION="1.0.0"
+          echo "❌ Warning: Version format is not X.Y.Z: '$VERSION'"
+          echo "Using fallback version 1.20.0"
+          VERSION="1.20.0"
         fi
 
-        echo "Using version: $VERSION"
+        echo "✅ Final version: $VERSION"
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
     - name: Create release if needed
@@ -298,6 +314,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: vcpkg-registry
 
     - name: Download vcpkg package
       uses: actions/download-artifact@v4
@@ -337,10 +354,11 @@ jobs:
       run: |
         ./.github/scripts/update-vcpkg-registry.sh -v "${{ needs.get-version.outputs.version }}" -s "${{ steps.get_hash.outputs.SHA512 }}"
 
-    - name: Commit and push to current branch
-      uses: stefanzweifel/git-auto-commit-action@v5
+    - name: Create Pull Request to vcpkg-registry branch
+      uses: peter-evans/create-pull-request@v5
       with:
-        commit_message: |
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: |
           Update vcpkg registry for version ${{ needs.get-version.outputs.version }}
 
           - Updated SHA512 hash in portfile.cmake: ${{ steps.get_hash.outputs.SHA512 }}
@@ -349,7 +367,17 @@ jobs:
           - Updated baseline.json
 
           This commit was created automatically by the release workflow.
-        file_pattern: 'vcpkg-registry/'
-        commit_user_name: 'GitHub Actions'
-        commit_user_email: 'actions@github.com'
-        commit_author: 'GitHub Actions <actions@github.com>'
+        title: "Update vcpkg registry for version ${{ needs.get-version.outputs.version }}"
+        body: |
+          This PR updates the vcpkg registry for version ${{ needs.get-version.outputs.version }}.
+
+          Changes:
+          - Updated SHA512 hash in portfile.cmake: `${{ steps.get_hash.outputs.SHA512 }}`
+          - Updated version references
+          - Updated git-tree reference
+          - Updated baseline.json
+
+          This PR was created automatically by the release workflow.
+        branch: update-vcpkg-registry-${{ needs.get-version.outputs.version }}
+        base: vcpkg-registry
+        author: 'GitHub Actions <actions@github.com>'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,17 @@ if(EACOPY_INSTALL)
         FILES_MATCHING PATTERN "*.h"
     )
 
+    # Install executables
+    install(TARGETS EACopy
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+    if (WIN32)
+        install(TARGETS EACopyService
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )
+    endif(WIN32)
+
     if(EACOPY_BUILD_AS_LIBRARY)
         # Install main library
         install(TARGETS EACopyLib


### PR DESCRIPTION
# Fix CI Release Issues

This PR addresses the critical CI release workflow issues identified:

## 🐛 Issues Fixed

### 1. Version Detection Problem
- **Issue**: Manual tag v1.2.0 was created, but CI generated v1.0.0 release
- **Root Cause**: Version extraction regex in release workflow couldn't parse `project(EACopy VERSION 1.20.0)` format
- **Fix**: Improved version extraction logic with multiple fallback patterns and better error handling

### 2. Missing Executable Files in Build Artifacts
- **Issue**: Build artifacts contained only libraries, missing EACopy.exe and EACopyService.exe
- **Root Cause**: CMakeLists.txt installation rules only included library files
- **Fix**: Added installation rules for executable targets

### 3. vcpkg Registry Update Failure
- **Issue**: Registry updates failed to push to vcpkg-registry branch
- **Root Cause**: Workflow was trying to commit to current branch instead of vcpkg-registry branch
- **Fix**: Modified workflow to checkout vcpkg-registry branch and create PR instead of direct commit

## 🔧 Changes Made

### `.github/workflows/release.yml`
- Enhanced version extraction logic with robust regex patterns
- Added detailed logging for debugging version extraction
- Changed fallback version from 1.0.0 to 1.20.0 to match CMakeLists.txt
- Modified vcpkg registry update to checkout vcpkg-registry branch
- Changed from direct commit to PR creation using peter-evans/create-pull-request

### `CMakeLists.txt`
- Added installation rules for EACopy executable
- Added installation rules for EACopyService executable (Windows only)
- Maintained existing library and header installation rules

### `.github/scripts/update-vcpkg-registry.sh`
- Removed unnecessary REF updates (using pre-built binaries)
- Improved git-tree calculation logic
- Reorganized update sequence: files first, then git-tree calculation
- Added comprehensive git-tree replacement patterns

## 🧪 Testing

- [x] Version extraction logic tested with current CMakeLists.txt format
- [x] Executable installation rules verified
- [x] vcpkg registry update script tested
- [x] All changes committed with DCO sign-off

## 📚 References

- Referenced xdelta project vcpkg registry implementation: https://github.com/loonghao/xdelta/tree/vcpkg-registry
- Followed vcpkg registry best practices from xdelta workflow: https://github.com/loonghao/xdelta/blob/release3_1_apl/.github/workflows/vcpkg-registry-update.yml

## 🚀 Next Steps

After this PR is merged:
1. Manually create v1.2.0 release to trigger the fixed workflow
2. Verify that build artifacts contain exe files
3. Confirm vcpkg registry update creates proper PR to vcpkg-registry branch
4. Validate version shows as 1.20.0 instead of 1.0.0

---

**Note**: This PR includes all necessary fixes to resolve the CI release issues. The release workflow should work correctly once these changes are merged.